### PR TITLE
docs: add IzzyOnDroid link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img alt="Logo" src="graphics/icon.webp" width="120" />
 
-<a href='https://play.google.com/store/apps/details?id=org.fossify.documents'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png' height=80/></a>
+<a href='https://play.google.com/store/apps/details?id=org.fossify.documents'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png' height=80/></a> <a href="https://apt.izzysoft.de/fdroid/index/apk/org.fossify.documents"><img src="https://gitlab.com/IzzyOnDroid/repo/-/raw/master/assets/IzzyOnDroid.png" alt="Get it on IzzyOnDroid" height=80/></a>
 
 Fossify Documents is a private, offline document reader and organizer for Android.
 


### PR DESCRIPTION
Adds the official IzzyOnDroid badge and package link to the README, matching the other Fossify repositories. The package page and badge asset both resolve successfully.